### PR TITLE
Replace ^ with String.concat

### DIFF
--- a/runtime/ppx_pyformat_runtime.ml
+++ b/runtime/ppx_pyformat_runtime.ml
@@ -22,9 +22,7 @@ let align_center c w s =
     String.make left_l c ^ s ^ String.make right_l c
 
 type padding_config = char * int
-
 type sign = Plus | Minus | Space
-
 type grouping_option = Comma | Underscore
 
 (** get sign string of number *)
@@ -36,7 +34,6 @@ let sign_str_of_num is_positive sign num =
   | _ -> "-"
 
 let sign_str_of_int = sign_str_of_num (fun num -> num >= 0)
-
 let sign_str_of_float = sign_str_of_num (fun num -> not (Float.sign_bit num))
 
 let grouping_config_of_grouping_option grouping_option =

--- a/runtime/ppx_pyformat_runtime.mli
+++ b/runtime/ppx_pyformat_runtime.mli
@@ -1,13 +1,9 @@
 val align_left : char -> int -> string -> string
-
 val align_right : char -> int -> string -> string
-
 val align_center : char -> int -> string -> string
 
 type padding_config = char * int
-
 type sign = Plus | Minus | Space
-
 type grouping_option = Comma | Underscore
 
 val int_to_binary :

--- a/src/rewriter.ml
+++ b/src/rewriter.ml
@@ -41,10 +41,15 @@ let generate_format_expr ~loc ?(args = []) (str : string) : P.expression =
     |> Utils.parse
     |> validate_positional_args ~loc ~length:(List.length args)
     |> List.map (Element_gen.string_expr_of_element ~loc)
-    |> Ast_builder.elist ~loc
-    |> fun list_expr ->
-    let open P in
-    [%expr String.concat "" [%e list_expr]]
+    |> function
+    | [] ->
+        let open P in
+        [%expr ""]
+    | [ expr ] -> expr
+    | expr_list ->
+        let list_expr = Ast_builder.elist ~loc expr_list in
+        let open P in
+        [%expr String.concat "" [%e list_expr]]
   in
   if List.length args > 0 then
     let bindings = List.mapi value_binding_of_arg args in

--- a/src/rewriter.ml
+++ b/src/rewriter.ml
@@ -46,6 +46,9 @@ let generate_format_expr ~loc ?(args = []) (str : string) : P.expression =
         let open P in
         [%expr ""]
     | [ expr ] -> expr
+    | [ expr_1; expr_2 ] ->
+        let open P in
+        [%expr [%e expr_1] ^ [%e expr_2]]
     | expr_list ->
         let list_expr = Ast_builder.elist ~loc expr_list in
         let open P in

--- a/src/rewriter.ml
+++ b/src/rewriter.ml
@@ -1,4 +1,5 @@
 module P = Ppxlib
+module Ast_builder = Ppxlib.Ast_builder.Default
 module Ast_helper = Ppxlib.Ast_helper
 
 let concat_lid : Longident.t = Lident "^"
@@ -40,20 +41,10 @@ let generate_format_expr ~loc ?(args = []) (str : string) : P.expression =
     |> Utils.parse
     |> validate_positional_args ~loc ~length:(List.length args)
     |> List.map (Element_gen.string_expr_of_element ~loc)
-    |> fun exprs ->
-    match exprs with
-    | [] ->
-        let open P in
-        [%expr ""]
-    | hd :: tl ->
-        List.fold_left
-          (fun acc cur ->
-            let concat_expr =
-              Ast_helper.Exp.ident P.{ txt = concat_lid; loc }
-            in
-            Ast_helper.Exp.apply ~loc concat_expr
-              [ (Nolabel, acc); (Nolabel, cur) ])
-          hd tl
+    |> Ast_builder.elist ~loc
+    |> fun list_expr ->
+    let open P in
+    [%expr String.concat "" [%e list_expr]]
   in
   if List.length args > 0 then
     let bindings = List.mapi value_binding_of_arg args in

--- a/src/type_utils.ml
+++ b/src/type_utils.ml
@@ -3,7 +3,6 @@ open Types
 type mode = Auto of int | Manual
 
 let arg_mode : mode option ref = ref None
-
 let reset_arg_mode _ = arg_mode := None
 
 let set_arg_manual _ =

--- a/src/types.ml
+++ b/src/types.ml
@@ -1,26 +1,18 @@
 exception KeyError of string
-
 exception TypeError of string
-
 exception ValueError of string
 
 type arg = Digit of int | Identifier of string list
-
 type index = List_index of int
-
 type align = Left | Right | Center | Pad
-
 type sign = Plus | Minus | Space
 
 type fill = { align : align; [@main] char_ : char; width : int }
 [@@deriving make]
 
 type grouping_option = Comma | Underscore
-
 type int_type = Binary | Char | Decimal | Octal | Hex
-
 type float_type = Scientific | Fixed | General | Percentage
-
 type type_ = String | Int of int_type | Float of float_type
 
 type raw_format_spec = {
@@ -46,7 +38,6 @@ type raw_replacement_field = {
 [@@deriving make]
 
 type raw_element = Raw_text of string | Raw_field of raw_replacement_field
-
 type raw_elements = raw_element list
 
 type format_spec =
@@ -79,5 +70,4 @@ type replacement_field = {
 [@@deriving make]
 
 type element = Text of string | Field of replacement_field
-
 type elements = element list

--- a/src/types.mli
+++ b/src/types.mli
@@ -1,26 +1,18 @@
 exception KeyError of string
-
 exception TypeError of string
-
 exception ValueError of string
 
 type arg = Digit of int | Identifier of string list
-
 type index = List_index of int
-
 type align = Left | Right | Center | Pad
-
 type sign = Plus | Minus | Space
 
 type fill = { align : align; [@main] char_ : char; width : int }
 [@@deriving make]
 
 type grouping_option = Comma | Underscore
-
 type int_type = Binary | Char | Decimal | Octal | Hex
-
 type float_type = Scientific | Fixed | General | Percentage
-
 type type_ = String | Int of int_type | Float of float_type
 
 type raw_format_spec = {
@@ -46,7 +38,6 @@ type raw_replacement_field = {
 [@@deriving make]
 
 type raw_element = Raw_text of string | Raw_field of raw_replacement_field
-
 type raw_elements = raw_element list
 
 type format_spec =
@@ -79,5 +70,4 @@ type replacement_field = {
 [@@deriving make]
 
 type element = Text of string | Field of replacement_field
-
 type elements = element list

--- a/src/utils.mli
+++ b/src/utils.mli
@@ -1,3 +1,2 @@
 val get_arg_name : int -> string
-
 val parse : string -> Types.elements

--- a/test/parser/utils.ml
+++ b/test/parser/utils.ml
@@ -6,9 +6,7 @@ let make_field ?index ?conversion ?(format_spec = format_spec) arg =
   Field (make_replacement_field ~arg ?index ?conversion ~format_spec ())
 
 let make_string = make_string_format_of_format_spec
-
 let make_int = make_int_format_of_format_spec
-
 let make_float = make_float_format_of_format_spec
 
 let test str expected _ =

--- a/test/rewriter/test_pyformat_rewriter.ml
+++ b/test/rewriter/test_pyformat_rewriter.ml
@@ -62,8 +62,7 @@ let format_spec_tests =
          "alternate_form" >:: test "0b1" [%pyformat "{b1:#b}"];
          grouping_option_tests;
          "underscore_grouping" >:: test "1_0000" [%pyformat "{b2:_b}"];
-         "upper" >:: test "A" [%pyformat "{x1:X}"];
-         (* precision_tests;*)
+         "upper" >:: test "A" [%pyformat "{x1:X}"] (* precision_tests;*);
        ]
 
 let string_tests =

--- a/test/rewriter/test_pyformat_rewriter.ml
+++ b/test/rewriter/test_pyformat_rewriter.ml
@@ -8,6 +8,7 @@ let text_tests =
          "simple" >:: test "123abcABC,.;' \t\n" [%pyformat "123abcABC,.;' \t\n"];
          "curl_escape" >:: test "{}}{" [%pyformat "{{}}}}{{"];
          "consolidation" >:: test "123{}321" [%pyformat "123{{}}321"];
+         "empty" >:: test "" [%pyformat ""];
        ]
 
 let index_tests =
@@ -168,7 +169,12 @@ let arg_tests =
                  s1;
                  s2;
                  "!"];
-         "mixed"
+         "mixed_1"
+         >:: test "hello world!"
+               [%pyformat
+                 "{0} world!";
+                 s1];
+         "mixed_2"
          >:: test "hello world!"
                [%pyformat
                  "{s1} {s2}{0}";

--- a/test/runtime/test_pyformat_runtime.ml
+++ b/test/runtime/test_pyformat_runtime.ml
@@ -45,5 +45,4 @@ let align_tests =
        ]
 
 let suite = "test_pyformat_runtime" >::: [ align_tests; Int.suite; Float.suite ]
-
 let _ = run_test_tt_main suite


### PR DESCRIPTION
Per suggestion from https://discuss.ocaml.org/t/ann-first-release-of-ppx-pyformat-0-1-1/9321/5

This could increase the runtime performance for most cases.